### PR TITLE
Added firefox support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,19 +10,21 @@
     "64": "images/thrive_icon_64.png",
     "128": "images/thrive_icon_128.png"
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{78ea5d0e-1d9c-40f1-a3eb-55fd58cd0758}",
+      "strict_min_version": "58.0"
+    }
+  },
   "action": {
     "default_popup": "popup.html"
   },
   "options_page": "options.html",
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
-  "permissions": [
-    "scripting",
-    "tabs",
-    "webNavigation",
-    "storage"
-  ],
+  "permissions": ["scripting", "tabs", "webNavigation", "storage"],
   "host_permissions": [
     "https://www.youtube.com/*",
     "https://m.youtube.com/*",


### PR DESCRIPTION
All that seems was needed to add firefox support was to add a id and min version for firefox specifically, id chosen is just a random uuid although it can also be an email address  see my comment here https://github.com/Nathansmiranda/UnInternet/issues/2#issuecomment-3845737498,

I also had to use `background.scripts` in addition to `background.service_worker` as firefox does not yet support `background.service_worker`, this does cause a warning when loading it into a chromium based browser but does not stop it from running see [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support)

One last note, sorry for putting permissions on one line I have auto formatting on.